### PR TITLE
262 upgrade native dependencies

### DIFF
--- a/mindbox/CHANGELOG.md
+++ b/mindbox/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* Upgrade iOS SDK dependency to v.2.1.1.
+* Upgrade Android SDK dependency to v2.1.4.
+
 ## 2.1.0
 
 * Upgrade iOS SDK dependency to v.2.1.0.

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox
 description: Flutter Mindbox SDK. Plugin wrapper over of Mindbox iOS/Android SDK.
-version: 2.1.0
+version: 2.1.1
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox
 publish_to: none

--- a/mindbox_android/CHANGELOG.md
+++ b/mindbox_android/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.1.0
 
+* Upgrade native SDK dependency to v2.1.4.
+
+## 2.1.0
+
 * Upgrade native SDK dependency to v2.1.3.
 * Update init method: you can change sdk configuration without reinstallation of app.
 

--- a/mindbox_android/CHANGELOG.md
+++ b/mindbox_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0
+## 2.1.1
 
 * Upgrade native SDK dependency to v2.1.4.
 

--- a/mindbox_android/README.md
+++ b/mindbox_android/README.md
@@ -1,9 +1,9 @@
 # mindbox_android
-***
+
 The Android implementation of [`mindbox`][1] plugin. 
 
 ## Usage
-***
+
 You can simply use [`mindbox`][1] normally. This package will be automatically included in your app when you do.
 
 [1]: ../mindbox

--- a/mindbox_android/android/build.gradle
+++ b/mindbox_android/android/build.gradle
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'cloud.mindbox:mobile-sdk:2.1.3'
+    implementation 'cloud.mindbox:mobile-sdk:2.1.4'
 }

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_android
 description: The implementation of 'mindbox' plugin for the Android platform.
-version: 2.1.0
+version: 2.1.1
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
 publish_to: none
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   mindbox_platform_interface:
-    path: ../../flutter-sdk/mindbox
+    path: ../../flutter-sdk/mindbox_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/mindbox_ios/CHANGELOG.md
+++ b/mindbox_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Upgrade native SDK dependency to v.2.1.1.
+
 ## 2.1.0
 
 * Upgrade native SDK dependency to v.2.1.0.

--- a/mindbox_ios/README.md
+++ b/mindbox_ios/README.md
@@ -1,8 +1,9 @@
 # mindbox_ios
-***
+
 The iOS implementation of [`mindbox`][1] plugin. 
+
 ## Usage
-***
+
 You can simply use [`mindbox`][1] normally. This package will be automatically included in your app when you do.
 
 [1]: ../mindbox

--- a/mindbox_ios/ios/mindbox_ios.podspec
+++ b/mindbox_ios/ios/mindbox_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mindbox_ios'
-  s.version          = '2.1.0'
+  s.version          = '2.1.1'
   s.summary          = 'Mindbox Flutter SDK'
   s.description      = <<-DESC
 The implementation of 'mindbox' plugin for the iOS platform
@@ -15,8 +15,8 @@ The implementation of 'mindbox' plugin for the iOS platform
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mindbox', '2.1.0'
-  s.dependency 'MindboxNotifications', '2.1.0'
+  s.dependency 'Mindbox', '2.1.1'
+  s.dependency 'MindboxNotifications', '2.1.1'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/mindbox_ios/pubspec.yaml
+++ b/mindbox_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_ios
 description: The implementation of 'mindbox' plugin for the iOS platform.
-version: 2.1.0
+version: 2.1.1
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_ios
 publish_to: none
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   mindbox_platform_interface:
-    path: ../../flutter-sdk/mindbox
+    path: ../../flutter-sdk/mindbox_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/mindbox_platform_interface/lib/src/types/mindbox_method_handler.dart
+++ b/mindbox_platform_interface/lib/src/types/mindbox_method_handler.dart
@@ -47,6 +47,7 @@ class MindboxMethodHandler {
   /// Read more about [Configuration] parameter.
   Future<void> init({required Configuration configuration}) async {
     try {
+      //ignore: unnecessary_null_comparison
       if (ServicesBinding.instance == null) {
         throw MindboxInitializeError(
             message: 'Initialization error',


### PR DESCRIPTION
Ticket: https://github.com/mindbox-moscow/issues-mobile-sdk/issues/262

Changes:
- upgrade iOS SDK dependency to v2.1.1
- upgrade Android SDK dependency to v2.1.4