### PR TITLE
Upgrade Android SDK version to 2.1.5

### DIFF
--- a/mindbox/CHANGELOG.md
+++ b/mindbox/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+* Upgrade Android SDK dependency to v2.1.5.
+* Upgrade HMS upgraded to 6.5.0.300.
+* Fix bug on Android after reinitialization (changing your domain, endpoint and shouldCreateCustomer parameters in existing SDK integration).
+
 ## 2.1.1
 
 * Upgrade iOS SDK dependency to v.2.1.1.

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox
 description: Flutter Mindbox SDK. Plugin wrapper over of Mindbox iOS/Android SDK.
-version: 2.1.1
+version: 2.1.2
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox
 publish_to: none

--- a/mindbox_android/CHANGELOG.md
+++ b/mindbox_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2
+
+* Upgrade Native SDK dependency to v2.1.5.
+* Upgrade HMS upgraded to 6.5.0.300.
+* Fix bug on Android after reinitialization (changing your domain, endpoint and shouldCreateCustomer parameters in existing SDK integration).
+
 ## 2.1.1
 
 * Upgrade native SDK dependency to v2.1.4.

--- a/mindbox_android/android/build.gradle
+++ b/mindbox_android/android/build.gradle
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'cloud.mindbox:mobile-sdk:2.1.4'
+    implementation 'cloud.mindbox:mobile-sdk:2.1.5'
 }

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_android
 description: The implementation of 'mindbox' plugin for the Android platform.
-version: 2.1.1
+version: 2.1.2
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
 publish_to: none


### PR DESCRIPTION
Issue: https://github.com/mindbox-moscow/issues-mobile-sdk/issues/268

Changes:
* Upgrade Android SDK dependency to v2.1.5.
* Upgrade HMS upgraded to 6.5.0.300.
* Fix bug on Android after reinitialization (changing your domain, endpoint and shouldCreateCustomer parameters in existing SDK integration).