### PR TITLE
282 upgrade native dependencies

### DIFF
--- a/mindbox/CHANGELOG.md
+++ b/mindbox/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 2.1.5
+
+* Upgrade Android SDK dependency to v2.1.9.
+* Upgrade iOS Mindbox SDK dependency to v2.1.5.
+
 ## 2.1.4
+
 * Upgrade Android SDK dependency to v2.1.6.
 
 ## 2.1.3

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -1,8 +1,9 @@
 name: mindbox
 description: Flutter Mindbox SDK. Plugin wrapper over of Mindbox iOS/Android SDK.
-version: 2.1.4
+version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,11 +20,14 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mindbox_android: ^2.1.3
-  mindbox_ios: ^2.1.2
-  mindbox_platform_interface: ^2.1.0
+  mindbox_android:
+    path: ../mindbox_android
+  mindbox_ios:
+    path: ../mindbox_ios
+  mindbox_platform_interface:
+    path: ../mindbox_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/mindbox_android/CHANGELOG.md
+++ b/mindbox_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+* Upgrade native SDK dependency to v2.1.9.
+
 ## 2.1.3
 
 * Upgrade native SDK dependency to v2.1.6.

--- a/mindbox_android/android/build.gradle
+++ b/mindbox_android/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -43,11 +43,11 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 31
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'cloud.mindbox:mobile-sdk:2.1.8'
+    implementation 'cloud.mindbox:mobile-sdk:2.1.9'
 }

--- a/mindbox_android/android/build.gradle
+++ b/mindbox_android/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -43,11 +43,11 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'cloud.mindbox:mobile-sdk:2.1.6'
+    implementation 'cloud.mindbox:mobile-sdk:2.1.8'
 }

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_android
 description: The implementation of 'mindbox' plugin for the Android platform.
-version: 2.1.5
+version: 2.1.4
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
 publish_to: none

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -1,8 +1,9 @@
 name: mindbox_android
 description: The implementation of 'mindbox' plugin for the Android platform.
-version: 2.1.3
+version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,9 +20,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mindbox_platform_interface: ^2.1.0
+  mindbox_platform_interface:
+    path: ../mindbox_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/mindbox_ios/CHANGELOG.md
+++ b/mindbox_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.3
+* Upgrade Native SDK dependency to v2.1.5.
+
 ## 2.1.2
 
 * Upgrade Native SDK dependency to v2.1.2.

--- a/mindbox_ios/ios/mindbox_ios.podspec
+++ b/mindbox_ios/ios/mindbox_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mindbox_ios'
-  s.version          = '2.1.5'
+  s.version          = '2.1.3'
   s.summary          = 'Mindbox Flutter SDK'
   s.description      = <<-DESC
 The implementation of 'mindbox' plugin for the iOS platform

--- a/mindbox_ios/ios/mindbox_ios.podspec
+++ b/mindbox_ios/ios/mindbox_ios.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'mindbox_ios'
-  s.version          = '2.1.2'
+  s.version          = '2.1.5'
   s.summary          = 'Mindbox Flutter SDK'
   s.description      = <<-DESC
 The implementation of 'mindbox' plugin for the iOS platform
@@ -15,8 +15,8 @@ The implementation of 'mindbox' plugin for the iOS platform
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mindbox', '2.1.2'
-  s.dependency 'MindboxNotifications', '2.1.2'
+  s.dependency 'Mindbox', '2.1.5'
+  s.dependency 'MindboxNotifications', '2.1.5'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/mindbox_ios/pubspec.yaml
+++ b/mindbox_ios/pubspec.yaml
@@ -1,8 +1,9 @@
 name: mindbox_ios
 description: The implementation of 'mindbox' plugin for the iOS platform.
-version: 2.1.2
+version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_ios
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,9 +19,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mindbox_platform_interface: ^2.1.0
+  mindbox_platform_interface:
+    path: ../mindbox_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/mindbox_ios/pubspec.yaml
+++ b/mindbox_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_ios
 description: The implementation of 'mindbox' plugin for the iOS platform.
-version: 2.1.5
+version: 2.1.3
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_ios
 publish_to: none

--- a/mindbox_platform_interface/CHANGELOG.md
+++ b/mindbox_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Update linter flutter_lints to 2.0.1
+
 ## 2.1.0
 
 * Update MindboxMethodHandler init method: you can change sdk configuration without reinstallation of app.

--- a/mindbox_platform_interface/pubspec.yaml
+++ b/mindbox_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mindbox_platform_interface
 description: Mindbox platform interface.
-version: 2.1.5
+version: 2.1.1
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_platform_interface
 publish_to: none

--- a/mindbox_platform_interface/pubspec.yaml
+++ b/mindbox_platform_interface/pubspec.yaml
@@ -1,8 +1,9 @@
 name: mindbox_platform_interface
 description: Mindbox platform interface.
-version: 2.1.0
+version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_platform_interface
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -15,4 +16,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
Ticket: https://github.com/mindbox-moscow/issues-mobile-sdk/projects/8

Changes:
* Upgrade Android SDK dependency to v2.1.9.
* Upgrade iOS Mindbox SDK dependency to v2.1.5.