### PR TITLE
Release/2.1.6

### DIFF
--- a/mindbox/CHANGELOG.md
+++ b/mindbox/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.1.5
 
+* Upgrade Android SDK dependency to v2.1.10.
+* Previously, in some cases on Android the picture in rich-push notifications was not displayed when the phone was turned off. Now we fixed it.
+
+## 2.1.5
+
 * Upgrade Android SDK dependency to v2.1.9.
 * Upgrade iOS Mindbox SDK dependency to v2.1.5.
 

--- a/mindbox/CHANGELOG.md
+++ b/mindbox/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.5
+## 2.1.6
 
 * Upgrade Android SDK dependency to v2.1.10.
 * Previously, in some cases on Android the picture in rich-push notifications was not displayed when the phone was turned off. Now we fixed it.

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -1,8 +1,10 @@
 name: mindbox
 description: Flutter Mindbox SDK. Plugin wrapper over of Mindbox iOS/Android SDK.
-version: 2.1.5
+version: 2.1.6
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox
+
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,7 +21,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mindbox_android: ^2.1.4
+  mindbox_android:
+    path: ../mindbox_android
   mindbox_ios: ^2.1.3
   mindbox_platform_interface: ^2.1.1
 

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -4,8 +4,6 @@ version: 2.1.6
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox
 
-publish_to: 'none'
-
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"
@@ -21,8 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mindbox_android:
-    path: ../mindbox_android
+  mindbox_android: ^2.1.5
   mindbox_ios: ^2.1.3
   mindbox_platform_interface: ^2.1.1
 

--- a/mindbox/pubspec.yaml
+++ b/mindbox/pubspec.yaml
@@ -27,3 +27,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
+  

--- a/mindbox_android/CHANGELOG.md
+++ b/mindbox_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.5
+
+* Upgrade native SDK dependency to v2.1.10.
+* Previously, in some cases the picture in rich-push notifications was not displayed when the phone was turned off. Now we fixed it.
+
 ## 2.1.4
 
 * Upgrade native SDK dependency to v2.1.9.

--- a/mindbox_android/android/build.gradle
+++ b/mindbox_android/android/build.gradle
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'cloud.mindbox:mobile-sdk:2.1.9'
+    implementation 'cloud.mindbox:mobile-sdk:2.1.10'
 }

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -4,8 +4,6 @@ version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
 
-publish_to: 'none'
-
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -1,8 +1,10 @@
 name: mindbox_android
 description: The implementation of 'mindbox' plugin for the Android platform.
-version: 2.1.4
+version: 2.1.5
 homepage: https://mindbox.cloud/
 repository: https://github.com/mindbox-moscow/flutter-sdk/tree/master/mindbox_android
+
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/mindbox_android/pubspec.yaml
+++ b/mindbox_android/pubspec.yaml
@@ -25,3 +25,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
+  


### PR DESCRIPTION
## 2.1.6

* Upgrade Android SDK dependency to v2.1.10.
* Previously, in some cases on Android the picture in rich-push notifications was not displayed when the phone was turned off. Now we fixed it.